### PR TITLE
Adds Resource Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,43 +4,26 @@ A simple Godot dialog addon to use in any kind of project.
 ![Screenshot](https://coppolaemilio.com/godot/dialog-screenshot.png)
 
 ## How to use:
-You first need to create a `global.gd` and a `characters.gd` script for storing variables.  
+You first need to create a `DialogCharacterResource` for each character you wish to have in your dialog.
+To do this, right click in your FileSystem and choose `New Resource`, search for `DialogCharacterResource` and create it.
+It's good practice to put these inside a `Resources/Characters` folder.
+You can assign each character a Name, Image and Color.
 
-Inside your `global.gd` add a dictionary variable called `custom_variables`.  
-`var custom_variables = {}`.
+Once you have created your characters it's time to create a `DialogResource` for your dialog.
+Note you can create a separate dialog resource for each of your dialogs if you wish to keep things logically separate, or you can create a master `DialogResource` if you prefer.
+To create a `DialogResource`, right click in your FileSystem and choose `New Resource`, search for `DialogResource` and create it.
+Again, it's good practice to put these inside a folder such as `Resources/Dialogs`.
+Each `DialogResource` can contain a Dictionary of custom variables that will be replaced by their value when you add them to a script in the form of "This is a [custom] value" where the value for the dictionary key `custom` will replace `[custom]`.
+You must also provide the `DialogResource` with an array of your `DialogCharacterResource` files.
+You can set the dialog script (.json) on the inspector variable "Dialog Json" or by setting the dialog content by changing the variable `dialog_script` of the node.
 
-On your `characters.gd` you need to define your custom characters. If you want to run the example you can copy and paste this values:
-```
-extends Node
-
-var Zas = {
-	'name': 'Zas',
-	'image': "res://addons/dialogs/Images/portraits/df-1.png",
-	'color': Color(0.304688, 0.445923, 1)
-}
-
-var Kubuk = {
-	'name': 'Kubuk',
-	'image': "res://addons/dialogs/Images/portraits/df-2.png",
-	'color': Color(0.632689, 0.157166, 0.804688)
-}
-
-var Iteb = {
-	'name': 'Iteb',
-	'image': "res://addons/dialogs/Images/portraits/df-3.png",
-	'color': Color(0.253906, 1, 0.44043)
-}
-```
-
-Then go to: `Project`>`Project Settings...`>`AutoLoad` and add the script `global.gd` with name `global`, the script `characters.gd` with name `characters` and **enable** the `Singleton` option.
-
-![Screenshot](https://coppolaemilio.com/godot/dialog-script-settings.png)
-
-Now you can add the node `addons/dialogs/Dialog.tscn` to your scenes and use it on your projects.
-
-You can set the dialog script (.json) on the inspector variable "External File" or by setting the dialog content by changing the variable `dialog_script` of the node.
+Now you can add the node `addons/dialogs/Dialog.tscn` to your scenes, assign the desired `DialogResource` file and use it on your projects.
 
 ## Changelog
+v0.3
+ - Removed requirement for `global.gd` and `characters.gd` autoload scripts.
+ - Added `DialogResource` and `DialogCharacterResource` resources to create a cleaner way of specifying dialog content
+
 v0.2:
  - Changed text speed to fixed per character instead of total time span
  - New character support

--- a/addons/dialogs/Nodes/Portrait.gd
+++ b/addons/dialogs/Nodes/Portrait.gd
@@ -13,7 +13,8 @@ func init(position_offset = 'left'):
 	rect_position += positions[position_offset]
 	direction = position_offset
 	modulate = Color(1,1,1,0)
-	$TextureRect.texture = load(character_data.image)
+	print(character_data.name)
+	$TextureRect.texture = character_data.image
 	print('height: ', $TextureRect.texture.get_height())
 	rect_position -= Vector2($TextureRect.texture.get_width() * 0.5, $TextureRect.texture.get_height())
 

--- a/addons/dialogs/dialog_character_resource.gd
+++ b/addons/dialogs/dialog_character_resource.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name DialogCharacterResource
+
+export var name : String
+export var image : Texture
+export var color : Color

--- a/addons/dialogs/dialog_node.gd
+++ b/addons/dialogs/dialog_node.gd
@@ -6,8 +6,10 @@ var finished = false
 var text_speed = 0.02 # Higher = lower speed
 var waiting_for_answer = false
 var waiting_for_input = false
+
+export(Resource) var dialog_resource
+
 onready var Portrait = load("res://addons/dialogs/Nodes/Portrait.tscn")
-export(String, FILE, "*.json") var extenal_file = ''
 var dialog_script = [
 	#{
 	#	'fade-in': 2
@@ -134,32 +136,36 @@ func parse_text(text):
 	
 	# for character variables
 	if '{' and '}' in end_text:
-		for c in characters.get_script().get_script_property_list():
-			var current = characters.get(c['name'])
-			if current['name'] in end_text:
-				end_text = end_text.replace('{' + current['name']+ '}',
-					'[color=#' + current['color'].to_html() + ']' + current['name'] + '[/color]'
+		for c in dialog_resource.characters:
+			if c.name in end_text:
+				end_text = end_text.replace('{' + c.name + '}',
+					'[color=#' + c.color.to_html() + ']' + c.name + '[/color]'
 				)
 		
 	var c_variable
-	for g in global.custom_variables:
-		if global.custom_variables.has(g):
-			c_variable = global.custom_variables[g]
-			# If it is a dictionary, get the label key
-			if typeof(c_variable) == TYPE_DICTIONARY:
-				if c_variable.has('label'):
-					if '.value' in end_text:
-						end_text = end_text.replace(g + '.value', c_variable['value'])
-					end_text = end_text.replace('[' + g + ']', c_variable['label'])
-			# Otherwise, just replace the value
-			else:
-				end_text = end_text.replace('[' + g + ']', c_variable)
+	for key in dialog_resource.custom_variables.keys():
+		c_variable = dialog_resource.custom_variables[key]
+		# If it is a dictionary, get the label key
+		if typeof(c_variable) == TYPE_DICTIONARY:
+			if c_variable.has('label'):
+				if '.value' in end_text:
+					end_text = end_text.replace('[' + key + '.value' + ']', c_variable['value'])
+				end_text = end_text.replace('[' + key + ']', c_variable['label'])
+		# Otherwise, just replace the value
+		else:
+			end_text = end_text.replace('[' + key + ']', c_variable)
 	return end_text
 
 func _ready():
 	# Checking if the dialog should read the code from a external file
-	if extenal_file != '':
-		dialog_script = file(extenal_file)
+	if dialog_resource.dialog_json != '':
+		dialog_script = file(dialog_resource.dialog_json)
+	
+	# Check if dialog has a valid resource file
+	if not dialog_resource or not dialog_resource.characters:
+		print("You must provide a valid DialogResource")
+		return
+	
 	# Setting everything up for the node to be default
 	$TextBubble/NameLabel.text = ''
 	$Background.visible = false
@@ -222,8 +228,9 @@ func load_dialog(skip_add = false):
 		dialog_index += 1
 
 func get_character_variable(name):
-	for c in characters.get_script().get_script_property_list():
-		return characters.get(name)
+	for c in dialog_resource.characters:
+		if c.name == name:
+			return c
 	return false
 
 func reset_dialog_extras():
@@ -336,14 +343,14 @@ func _on_input_set(variable):
 	if input_value == '':
 		$TextInputDialog.popup_centered()
 	else:
-		global.custom_variables[variable] = input_value
+		dialog_resource.custom_variables[variable] = input_value
 		waiting_for_input = false
 		$TextInputDialog/LineEdit.text = ''
 		$TextInputDialog.disconnect("confirmed", self, '_on_input_set')
 		$TextInputDialog.visible = false
 		load_dialog()
 		print('[!] Input selected: ', input_value)
-		print(global.custom_variables)
+		print(dialog_resource.custom_variables)
 
 func reset_options():
 	# Clearing out the options after one was selected.
@@ -360,12 +367,12 @@ func change_position(i, checkpoint):
 	load_dialog()
 
 func _on_option_selected(option, variable, value):
-	global.custom_variables[variable] = value
+	dialog_resource.custom_variables[variable] = value
 	waiting_for_answer = false
 	reset_options()
 	load_dialog()
 	print('[!] Option selected: ', option.text, ' value= ' , value)
-	print(global.custom_variables)
+	print(dialog_resource.custom_variables)
 
 func _on_Tween_tween_completed(object, key):
 	finished = true

--- a/addons/dialogs/dialog_resource.gd
+++ b/addons/dialogs/dialog_resource.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name DialogResource
+
+export(String, FILE, "*.json") var dialog_json : String
+export var custom_variables : Dictionary
+export(Array, Resource) var characters : Array


### PR DESCRIPTION
This PR removes the requirement for the developer to create auto-loaded `global.gd` and `characters.gd` scripts. The reason for doing so is that they are both very common names which may result in clashes in some projects, and also that creating extra auto-loaded singleton classes to fuel the dialog system does not seem like the best approach.

This PR proposes a cleaner solution using custom Godot Resources.

Namely a `DialogResource` which contains a reference to an external Json file for the dialog, a `Dictionary` of key/value custom variables, and an `Array` of `DialogCharacterResource` references.

And a `DialogCharacterResource` which contains a Name, an Image and Color.

Instead of creating a `global.gd` script that returns custom variables and a `characters.gd` script returning a dictionary of characters, developers can now create individual resource files for each character and dialog.

Video demo here:
https://twitter.com/codewithtom/status/1274151135776051206